### PR TITLE
Add Gmail settings update route and tests

### DIFF
--- a/gmail_oauth/__init__.py
+++ b/gmail_oauth/__init__.py
@@ -210,6 +210,24 @@ def get_gmail_status(user_id: str):
     except Exception as e:
         return JSONResponse(status_code=500, content={"error": "Failed to get Gmail status", "detail": str(e)})
 
+@router.post("/oauth/gmail/settings")
+def update_gmail_settings(settings: GmailSettingsUpdate):
+    try:
+        update_data = {"subject_filter": settings.subject_filter}
+        query = (
+            supabase
+            .table("email_tokens")
+            .update(update_data)
+            .eq("user_id", settings.user_id)
+            .eq("provider", "gmail")
+        )
+        if settings.token_id:
+            query = query.eq("id", settings.token_id)
+        result = query.execute()
+        return {"updated": result.data}
+    except Exception as e:
+        return JSONResponse(status_code=500, content={"error": "Failed to update Gmail settings", "detail": str(e)})
+
 @router.get("/oauth/gmail/callback")
 def gmail_oauth_callback(code: str, state: str):
     try:

--- a/tests/test_gmail_settings.py
+++ b/tests/test_gmail_settings.py
@@ -1,0 +1,63 @@
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+import types
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+os.environ.setdefault("SUPABASE_URL", "http://localhost")
+os.environ.setdefault("SUPABASE_KEY", "dummy")
+
+import gmail_oauth
+from gmail_oauth import router
+
+
+def test_update_subject_filter(monkeypatch):
+    class DummyQuery:
+        def __init__(self):
+            self.update_data = None
+            self.conditions = []
+
+        def update(self, data):
+            self.update_data = data
+            return self
+
+        def eq(self, column, value):
+            self.conditions.append((column, value))
+            return self
+
+        def execute(self):
+            return types.SimpleNamespace(
+                data=[
+                    {
+                        "id": 1,
+                        "user_id": "user1",
+                        "provider": "gmail",
+                        "subject_filter": self.update_data.get("subject_filter"),
+                    }
+                ]
+            )
+
+    class DummySupabase:
+        def table(self, name):
+            self.table_name = name
+            self.query = DummyQuery()
+            return self.query
+
+    dummy = DummySupabase()
+    monkeypatch.setattr(gmail_oauth, "supabase", dummy)
+
+    app = FastAPI()
+    app.include_router(router)
+    client = TestClient(app)
+
+    payload = {"user_id": "user1", "subject_filter": "Invoices", "token_id": 1}
+    resp = client.post("/oauth/gmail/settings", json=payload)
+
+    assert resp.status_code == 200
+    assert resp.json()["updated"][0]["subject_filter"] == "Invoices"
+    assert dummy.table_name == "email_tokens"
+    assert ("user_id", "user1") in dummy.query.conditions
+    assert ("provider", "gmail") in dummy.query.conditions
+    assert ("id", 1) in dummy.query.conditions
+


### PR DESCRIPTION
## Summary
- add `/oauth/gmail/settings` route to update Gmail token settings in Supabase
- test Gmail `subject_filter` update flow

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a4b31c0ff48330bad78538da2dce03