### PR TITLE
Add environment validation

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,13 +1,16 @@
+from dotenv import load_dotenv
+
+load_dotenv()
+
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from rotate_pdf import router as rotate_router
 from split_pdf import router as split_router
 from prepare_pdf import router as prepare_router
-from gmail_oauth import router as email_router  # jouw OAuth/router file
+from gmail_oauth import router as email_router, validate_env  # jouw OAuth/router file
 
-from dotenv import load_dotenv
-load_dotenv()
+validate_env()
 
 app = FastAPI()
 

--- a/gmail_oauth/__init__.py
+++ b/gmail_oauth/__init__.py
@@ -1,3 +1,16 @@
+"""OAuth helpers for Gmail and Outlook.
+
+Required environment variables:
+- ``GOOGLE_CLIENT_ID``
+- ``GOOGLE_CLIENT_SECRET``
+- ``GOOGLE_REDIRECT_URI``
+- ``MS_CLIENT_ID``
+- ``MS_CLIENT_SECRET``
+- ``MS_REDIRECT_URI``
+- ``SUPABASE_URL``
+- ``SUPABASE_KEY``
+"""
+
 from fastapi import APIRouter
 from fastapi.responses import RedirectResponse, JSONResponse, StreamingResponse
 import os, requests, datetime, time, re, base64, io, urllib.parse
@@ -7,6 +20,29 @@ from pydantic import BaseModel
 from typing import Optional, List, Dict
 
 load_dotenv()
+
+
+def validate_env() -> None:
+    """Validate presence of required environment variables."""
+    required_keys = [
+        "GOOGLE_CLIENT_ID",
+        "GOOGLE_CLIENT_SECRET",
+        "GOOGLE_REDIRECT_URI",
+        "MS_CLIENT_ID",
+        "MS_CLIENT_SECRET",
+        "MS_REDIRECT_URI",
+        "SUPABASE_URL",
+        "SUPABASE_KEY",
+    ]
+    missing = [k for k in required_keys if not os.getenv(k)]
+    if missing:
+        raise RuntimeError(
+            "Missing required environment variables: " + ", ".join(missing)
+        )
+
+
+validate_env()
+
 router = APIRouter()
 
 # === Config uit .env ===


### PR DESCRIPTION
## Summary
- add validate_env for Gmail and Outlook OAuth handlers
- call validate_env after loading .env in app startup
- document required environment variables

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a4b307f0a48330b140c7b9ed49f058