### PR TITLE
Consolidate logging configuration

### DIFF
--- a/app.py
+++ b/app.py
@@ -13,7 +13,10 @@ from gmail_oauth import router as email_router, validate_env  # jouw OAuth/route
 
 validate_env()
 
-logging.basicConfig(level=logging.INFO)
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+)
 logger = logging.getLogger(__name__)
 
 app = FastAPI()

--- a/gmail_oauth/__init__.py
+++ b/gmail_oauth/__init__.py
@@ -45,7 +45,6 @@ def validate_env() -> None:
 validate_env()
 
 router = APIRouter()
-logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 # === Config uit .env ===

--- a/prepare_pdf/__init__.py
+++ b/prepare_pdf/__init__.py
@@ -9,7 +9,6 @@ import logging
 import gc
 
 router = APIRouter()
-logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 Image.MAX_IMAGE_PIXELS = None
 

--- a/rotate_pdf/__init__.py
+++ b/rotate_pdf/__init__.py
@@ -10,7 +10,6 @@ import time
 import gc
 
 router = APIRouter()
-logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 def detect_rotation_angle(image: Image.Image) -> int:

--- a/split_pdf/__init__.py
+++ b/split_pdf/__init__.py
@@ -12,7 +12,6 @@ import gc
 
 Image.MAX_IMAGE_PIXELS = None
 router = APIRouter()
-logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 def extract_text(image: Image.Image):


### PR DESCRIPTION
## Summary
- centralize logging setup in `app.py` with a formatted output
- drop redundant `logging.basicConfig` calls from PDF utilities and OAuth module

## Testing
- `GOOGLE_CLIENT_ID=foo GOOGLE_CLIENT_SECRET=foo GOOGLE_REDIRECT_URI=foo MS_CLIENT_ID=foo MS_CLIENT_SECRET=foo MS_REDIRECT_URI=foo SUPABASE_URL=https://example.com SUPABASE_KEY=foo pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a4ba4946a0833092cf13ba1ce4b1a2