### PR TITLE
chore: remove unused logging imports

### DIFF
--- a/app.py
+++ b/app.py
@@ -4,7 +4,6 @@ load_dotenv()
 
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
-import logging
 from utils.logging import get_logger
 
 from rotate_pdf import router as rotate_router

--- a/gmail_oauth/__init__.py
+++ b/gmail_oauth/__init__.py
@@ -18,7 +18,6 @@ from supabase import create_client
 from dotenv import load_dotenv
 from pydantic import BaseModel
 from typing import Optional, List, Dict
-import logging
 from utils.logging import get_logger
 
 load_dotenv()

--- a/prepare_pdf/__init__.py
+++ b/prepare_pdf/__init__.py
@@ -5,7 +5,6 @@ from pdf2image import convert_from_bytes
 from PIL import Image, ImageOps
 import numpy as np
 import cv2
-import logging
 import gc
 from utils.logging import get_logger
 from utils.uploads import read_upload_file

--- a/rotate_pdf/__init__.py
+++ b/rotate_pdf/__init__.py
@@ -4,7 +4,6 @@ from pdf2image.exceptions import PDFInfoNotInstalledError, PDFPageCountError, PD
 from PIL import Image
 from pytesseract import TesseractError
 import pytesseract
-import logging
 import io
 import time
 import gc

--- a/split_pdf/__init__.py
+++ b/split_pdf/__init__.py
@@ -7,7 +7,6 @@ from PIL import Image
 from pyzbar.pyzbar import decode as decode_barcode
 import PyPDF2
 import time
-import logging
 import gc
 from utils.logging import get_logger
 from utils.uploads import read_upload_file


### PR DESCRIPTION
## Summary
- remove leftover logging imports from modules now using shared logger

## Testing
- `pip install flake8` *(fails: Could not find a version that satisfies the requirement flake8)*
- `flake8` *(not found)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a4c3db6e3c8330a590448e1c7b9c13